### PR TITLE
post request  http://ip/inkscopeCtrl/ceph/osd?depth=1   prompts "500 Internal Server Error"

### DIFF
--- a/inkscopeCtrl/inkscopeCtrl.wsgi
+++ b/inkscopeCtrl/inkscopeCtrl.wsgi
@@ -1,7 +1,14 @@
 #author Philippe Raipin
 #licence : apache v2
 
-import logging, sys
+import logging, sys, os
+ 
+abspath = os.path.dirname(__file__) 
+
+sys.path.append(abspath) 
+
+os.chdir(abspath)
+
 logging.basicConfig(stream=sys.stderr)
 
 sys.path.insert(0, '/var/www/inkscope/inkscopeCtrl')


### PR DESCRIPTION
When visiting the home page, the browser network bar prompts "500 Internal Server Error", the post url  is http://192.168.77.230:81/inkscopeCtrl/ceph/osd?depth=1.  Apache log show "mod_wsgi (pid=12877): Target WSGI script'/opt/inkscope/inkscopeCtrl/ inkscopeCtrl.wsgi'cannot be loaded as Python module., referer: http://192.168.77.230:81/inkscopeViz/index.html . The fixing  is instead the abs path of inkscopeCtrl.wsgi  with  Apache
