### PR TITLE
Fixes in inkscopeCtrl/S3ObjectCtrl.py

### DIFF
--- a/inkscopeCtrl/S3ObjectCtrl.py
+++ b/inkscopeCtrl/S3ObjectCtrl.py
@@ -234,7 +234,7 @@ class S3ObjectCtrl:
     def getOsdDump(self):
         Log.debug("___getOsdDump()")
         # print str(datetime.datetime.now()), "-- Process OSDDump"
-        cephRestUrl = request.url_root + self.clusterName + '/osd?depth=2'
+        cephRestUrl = request.url_root + self.cluster.get_fsid() + '/osd?depth=2'
         print(cephRestUrl)
         # Set HTTP credentials for url callback (requests.)
         data = requests.get(cephRestUrl)
@@ -245,7 +245,7 @@ class S3ObjectCtrl:
                 return osds
         r = data.content
 
-        if len(r) > 0:
+        if r != '[]':
            osds = json.loads(r)
         else:
             Log.err('The osd dump returns empty data')

--- a/inkscopeCtrl/S3ObjectCtrl.py
+++ b/inkscopeCtrl/S3ObjectCtrl.py
@@ -34,7 +34,7 @@ class S3ObjectCtrl:
             self.radosgw_url += '/'
         self.url = self.radosgw_url + self.admin
 
-        self.cluster = rados.Rados(conffile=self.conffile)
+        self.cluster = rados.Rados(conffile=str(self.conffile))
         print "\nlibrados version: " + str(self.cluster.version())
         print "Will attempt to connect to: " + str(self.cluster.conf_get('mon initial members'))
 
@@ -174,7 +174,7 @@ class S3ObjectCtrl:
 
     def getChunkSize(self, poolname, objectid):  # Method OK
         Log.info('___getChunkSize(poolName=' + str(poolname) + ', objectId=' + str(objectid) + ')')
-        ioctx = self.cluster.open_ioctx(poolname)
+        ioctx = self.cluster.open_ioctx(str(poolname))
         size = ioctx.stat(str(objectid))
 
         return int(size[0])
@@ -390,7 +390,7 @@ class S3ObjectCtrl:
 # An exception is thrown if the object does not exist or there an issue
     def getChunkBaseName(self, poolName, objectid):
         Log.info("____Get the chunks list for the object [" + objectid + "] and the pool[ " + str(poolName) + "]")
-        ioctx = self.cluster.open_ioctx(poolName)
+        ioctx = self.cluster.open_ioctx(str(poolName))
         xattr = ioctx.get_xattr(objectid, 'user.rgw.manifest')
         shadow = xattr.replace('\x00', '').replace('\x01', '').replace('\x02', '').replace('\x03', '').\
                       replace('\x04', '').replace('\x05', '').replace('\x06', '').replace('\x07', '').replace('\x08', '').replace('\x09', '')\


### PR DESCRIPTION
Two bugs in inkscopeCtrl/S3ObjectCtrl.py are fixed by this pull:
* Argument errors caused by unicode strings
* #37 getOsdDump() looks for wrong URL