### PR TITLE
fix object visualization bug on getChunkBaseName

### DIFF
--- a/inkscopeCtrl/S3ObjectCtrl.py
+++ b/inkscopeCtrl/S3ObjectCtrl.py
@@ -396,7 +396,7 @@ class S3ObjectCtrl:
     def getChunkBaseName(self, poolName, objectid):
         Log.info("____Get the chunks list for the object [" + objectid + "] and the pool[ " + str(poolName) + "]")
         ioctx = self.cluster.open_ioctx(str(poolName))
-        xattr = ioctx.get_xattr(objectid, 'user.rgw.manifest')
+        xattr = ioctx.get_xattr(str(objectid), 'user.rgw.manifest')
         shadow = xattr.replace('\x00', '').replace('\x01', '').replace('\x02', '').replace('\x03', '').\
                       replace('\x04', '').replace('\x05', '').replace('\x06', '').replace('\x07', '').replace('\x08', '').replace('\x09', '')\
                       .replace('\x10', '').replace('\x11', '').replace('\x12', '').replace('\x0e', '').replace('\x0b', '').replace('\x0c', '')


### PR DESCRIPTION
I got the problem when using RGW object visualization:

![screenshot from 2016-02-26 09 32 07](https://cloud.githubusercontent.com/assets/12855902/13341337/c225b41e-dc72-11e5-923a-281d0c731793.png)

so I open /var/log/apache2/error.log and see the following:

```
[Fri Feb 26 01:31:52.312637 2016] [:error] [pid 31676:tid 140596912002816] INFO     ____Get the chunks list for the object [default.5034.1_test_12M] and the pool[ .rgw.buckets]
[Fri Feb 26 01:31:52.315593 2016] [:error] [pid 31676:tid 140596912002816] ERROR    Exception on /S3/object [GET]
[Fri Feb 26 01:31:52.315605 2016] [:error] [pid 31676:tid 140596912002816] Traceback (most recent call last):
[Fri Feb 26 01:31:52.315607 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
[Fri Feb 26 01:31:52.315609 2016] [:error] [pid 31676:tid 140596912002816]     response = self.full_dispatch_request()
[Fri Feb 26 01:31:52.315620 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
[Fri Feb 26 01:31:52.315622 2016] [:error] [pid 31676:tid 140596912002816]     rv = self.handle_user_exception(e)
[Fri Feb 26 01:31:52.315624 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
[Fri Feb 26 01:31:52.315625 2016] [:error] [pid 31676:tid 140596912002816]     reraise(exc_type, exc_value, tb)
[Fri Feb 26 01:31:52.315627 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
[Fri Feb 26 01:31:52.315629 2016] [:error] [pid 31676:tid 140596912002816]     rv = self.dispatch_request()
[Fri Feb 26 01:31:52.315630 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
[Fri Feb 26 01:31:52.315632 2016] [:error] [pid 31676:tid 140596912002816]     return self.view_functions[rule.endpoint](**req.view_args)
[Fri Feb 26 01:31:52.315634 2016] [:error] [pid 31676:tid 140596912002816]   File "/var/www/inkscope/inkscopeCtrl/inkscopeCtrlcore.py", line 471, in getObjectStructure
[Fri Feb 26 01:31:52.315636 2016] [:error] [pid 31676:tid 140596912002816]     return Response(S3ObjectCtrl(conf).getObjectStructure(),mimetype='application/json')
[Fri Feb 26 01:31:52.315638 2016] [:error] [pid 31676:tid 140596912002816]   File "/var/www/inkscope/inkscopeCtrl/S3ObjectCtrl.py", line 84, in getObjectStructure
[Fri Feb 26 01:31:52.315639 2016] [:error] [pid 31676:tid 140596912002816]     chunkbasename = self.getChunkBaseName(poolname, extended_objectId)
[Fri Feb 26 01:31:52.315641 2016] [:error] [pid 31676:tid 140596912002816]   File "/var/www/inkscope/inkscopeCtrl/S3ObjectCtrl.py", line 399, in getChunkBaseName
[Fri Feb 26 01:31:52.315643 2016] [:error] [pid 31676:tid 140596912002816]     xattr = ioctx.get_xattr(objectid, 'user.rgw.manifest')
[Fri Feb 26 01:31:52.315644 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/rados.py", line 258, in validate_func
[Fri Feb 26 01:31:52.315646 2016] [:error] [pid 31676:tid 140596912002816]     check_type(arg_val, arg_name, arg_type)
[Fri Feb 26 01:31:52.315647 2016] [:error] [pid 31676:tid 140596912002816]   File "/usr/lib/python2.7/dist-packages/rados.py", line 248, in check_type
[Fri Feb 26 01:31:52.315649 2016] [:error] [pid 31676:tid 140596912002816]     raise TypeError('%s must be %s' % (arg_name, arg_type.__name__))
[Fri Feb 26 01:31:52.315651 2016] [:error] [pid 31676:tid 140596912002816] TypeError: key must be str
```
After check objectid variable, I see the type is not string object but unicode object, so it should be converted.

Ref:
http://docs.ceph.com/docs/hammer/rados/api/python/#writing-and-reading-xattrs
