### PR TITLE
allow "-d" as options for ceph-* command

### DIFF
--- a/inkscopeProbe/sysprobe.py
+++ b/inkscopeProbe/sysprobe.py
@@ -484,7 +484,7 @@ def pick_ceph_processes_v2(hostname, db):
     
     for ceph_proc in ceph_procs:
         # print ceph_proc, " ", ceph_proc.cmdline()[1:]
-        options, remainder = getopt.getopt(ceph_proc.cmdline()[1:], 'ic:f', ['cluster=', 'id', 'config', 'pid-file'])
+        options, remainder = getopt.getopt(ceph_proc.cmdline()[1:], 'ic:fd', ['cluster=', 'id', 'config', 'pid-file'])
         clust = None
         id = None
         


### PR DESCRIPTION
-d (Debug in foreground) options is used by kolla in order to retrieve logs (both stdout and stderr) and push them to Elasticsearch (used as centralized logging service)