### PR TITLE
Add an option to launch inkscopeProbes in foreground

### DIFF
--- a/inkscopeProbe/cephprobe.py
+++ b/inkscopeProbe/cephprobe.py
@@ -683,6 +683,11 @@ class CephProbeDaemon(Daemon):
         Daemon.__init__(self, pidfile, stdout=logfile, stderr=logfile)
         
     def run(self):
+        start_probe()
+
+    @staticmethod
+    def start_probe():
+
         print str(datetime.datetime.now()), "-- CephProbe loading"  
         # load conf
         conf = load_conf()
@@ -878,6 +883,8 @@ if __name__ == "__main__":
             daemon.status()
         elif 'restart' == sys.argv[1]:
             daemon.restart()
+        elif 'nodaemon' == sys.argv[1]:
+            CephProbeDaemon.start_probe()
         else:
             print "Unknown command"
             sys.exit(2)

--- a/inkscopeProbe/sysprobe.py
+++ b/inkscopeProbe/sysprobe.py
@@ -627,6 +627,11 @@ class SysProbeDaemon(Daemon):
         Daemon.__init__(self, pidfile, stdout=logfile, stderr=logfile)
         
     def run(self):
+        start_probe()
+
+    @staticmethod
+    def start_probe():
+
         print str(datetime.datetime.now())
         print "SysProbe loading"
         # load conf
@@ -849,6 +854,8 @@ if __name__ == "__main__":
             daemon.status()
         elif 'restart' == sys.argv[1]:
             daemon.restart()
+        elif 'nodaemon' == sys.argv[1]:
+            SysProbeDaemon.start_probe()
         else:
             print "Unknown command"
             sys.exit(2)


### PR DESCRIPTION
In containerized deployments of ceph (such as kolla or ceph-docker),
it may be desirable to have inkscope probes running in containers.

To that extent, probes have to be run in foreground, which is done
through the nodaemon option intoduced in this patch

This patch aims at fixing 3rd bullet of https://github.com/inkscope/inkscope/issues/74